### PR TITLE
Set producer in kvxml. Rebuild againt kvalobs version >= 5.0.5. 

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+kvqc2d (1.6.0~rc7-1) unstable; urgency=low
+
+  * Remove dependency on librdkafka. This is now part of libkvcpp.
+  * Set producer to kvqc2 in kv2kv-xml.
+  * kvqc2d depend on kvalobs version >= 5.0.5.
+
+ -- Alexander Bürger <alexander.buerger@met.no>  Thu, 25 Apr 2019 11:00:00 +0200
+
+
 kvqc2d (1.6.0~rc6-2) unstable; urgency=low
 
   * bugfix plu-autoupdate-from-stinfosys

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Build-Depends: debhelper (>= 9),
  libboost-filesystem-dev (>= 1.40.0),
  google-mock,
  python,
- libkvcpp-dev (>= 4.0),
+ libkvcpp-dev (>= 5.0.5~rc2),
  libcurl4-gnutls-dev | libcurl-dev
 Standards-Version: 3.9.2
 

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,6 @@ Build-Depends: debhelper (>= 9),
  google-mock,
  python,
  libkvcpp-dev (>= 4.0),
- librdkafka-dev (>= 0.9.1),
  libcurl4-gnutls-dev | libcurl-dev
 Standards-Version: 3.9.2
 

--- a/src/Qc2App.cc
+++ b/src/Qc2App.cc
@@ -172,7 +172,7 @@ bool Qc2App::sendDataToKvService(const std::list<kvalobs::kvData> &data, bool& b
     }
 
     using kvalobs::service::KvDataSerializeCommand;
-    KvDataSerializeCommand* dataCmd(new KvDataSerializeCommand(data));
+    KvDataSerializeCommand* dataCmd(new KvDataSerializeCommand(data, "kvqc2"));
     mProducerThread->send(dataCmd);
     LOGINFO("sent data to kafka, hope that the message arrives ...");
     busy = false;


### PR DESCRIPTION
1 test feiler. ``
Bygger mot kvalobs-5.0.5~rc1

Når jeg bygger med 
   
> debuild -b -us -uc 

Så feiler testen 

> GapInterpolationTest.DoNotSetTo80_1

Hvis jeg bygger med 


> mkdir build
> cd build
> cmake ..
> make
> test/kvqc2dTest

Så feiler ingen tester.

Jeg får ikke bygget debian pakken så jeg får ikke testet på staging.

